### PR TITLE
Remove kube type from teleport-kube-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,5 +121,5 @@ To allow the Teleport Kubernetes agent running in this cluster to join the Telep
 
 ```sh
 tsh login teleport.jdmarble.net
-kubectl --namespace teleport-kube-agent create secret generic teleport-kube-agent-join-token --from-literal=auth-token=$(tctl tokens add --type=kube,app --ttl=1h --format=text)
+kubectl --namespace teleport-kube-agent create secret generic teleport-kube-agent-join-token --from-literal=auth-token=$(tctl tokens add --type=app --ttl=1h --format=text)
 ```

--- a/manifests/teleport/kube-agent/application.yaml
+++ b/manifests/teleport/kube-agent/application.yaml
@@ -11,11 +11,10 @@ spec:
     targetRevision: 13.3.8
     helm:
       values: |
-        kubeClusterName: jdmarble.net
         proxyAddr: teleport.jdmarble.net:443
         joinTokenSecret:
           create: false
-        roles: kube,app
+        roles: app
         teleportConfig:
           app_service:
             debug_app: true


### PR DESCRIPTION
Since the teleport-cluster is deployed on this k8s cluster, having the agent also allow access to the cluster is redundant.

Closes #4 